### PR TITLE
Removed paper-sublistbox.html from main entry

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,8 +9,7 @@
     "listbox"
   ],
   "main": [
-    "paper-listbox.html",
-    "paper-sublistbox.html"
+    "paper-listbox.html"
   ],
   "private": true,
   "repository": {


### PR DESCRIPTION
I have removed an `paper-sublistbox.html` from `main` in `bower.json`.
The file does not exists, and should therefor not be listed there.